### PR TITLE
exclude FakeItEasy 2.0 from compatible versions

### DIFF
--- a/src/Autofac.Extras.FakeItEasy/Autofac.Extras.FakeItEasy.nuspec
+++ b/src/Autofac.Extras.FakeItEasy/Autofac.Extras.FakeItEasy.nuspec
@@ -14,7 +14,7 @@
     <iconUrl>http://code.google.com/p/autofac/logo</iconUrl>
     <dependencies>
       <dependency id="Autofac" version="[3.3.1,4.0.0)" />
-      <dependency id="FakeItEasy" version="1.18.0" />
+      <dependency id="FakeItEasy" version="[1.18.0,2.0.0)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
`IFakeOptionsBuilder<T>.OnFakeCreated()` and `IFakeOptionsBuilder<T>.Configure()` have been removed in FakeItEasy 2.0 (currently in beta) and replaced with `IFakeOptionsBuilder<T>.ConfigureFake()`.

This change restricts the package dependency to exclude FIE 2.0.

I would recommend merging this and releasing a new version of the package before FIE 2.0 is released so that a package upgrade after the release of FIE 2.0 won't break people.

A move to FIE 2.0 can then be handled separately with a new package release after FIE 2.0 has been released.