### PR TITLE
add mailmap to consolidate commits in the log

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Adam Ralph <adam@adamralph.com> Adam Ralph <unknown@kiln.example.com>
+Alex Meyer-Gleaves <alex.meyergleaves@gmail.com>
+Alex Meyer-Gleaves <alex.meyergleaves@gmail.com> alex.meyergleaves <unknown@kiln.example.com>
+Blair Conrad <blair@blairconrad.com>  Blair Conrad <blair.conrad@gmail.com>
+Travis Illig <tillig@paraesthesia.com> Travis@tillig-win8-vm <unknown@kiln.example.com>
+Travis Illig <tillig@paraesthesia.com> travis.illig@gmail.com <unknown@kiln.example.com>


### PR DESCRIPTION
Tidies up the commit log. Used to great effect in FakeItEasy/FakeItEasy#257

witness the `git shortlog -sne` comparison:

![image](https://cloud.githubusercontent.com/assets/3275797/6695578/b1d3410a-ccb8-11e4-99fe-b15a58e0b609.png)
