### PR TITLE
update to FakeItEasy 2.0.0-rc1

### DIFF
--- a/src/Autofac.Extras.FakeItEasy/Autofac.Extras.FakeItEasy.csproj
+++ b/src/Autofac.Extras.FakeItEasy/Autofac.Extras.FakeItEasy.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\..\packages\Autofac.3.3.1\lib\net40\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\FakeItEasy.2.0.0-beta007\lib\net40\FakeItEasy.dll</HintPath>
+      <HintPath>..\..\packages\FakeItEasy.2.0.0-rc1\lib\net40\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Autofac.Extras.FakeItEasy/FakeRegistrationHandler.cs
+++ b/src/Autofac.Extras.FakeItEasy/FakeRegistrationHandler.cs
@@ -137,7 +137,7 @@ namespace Autofac.Extras.FakeItEasy
         }
 
         [SecuritySafeCritical]
-        private void ApplyOptions<T>(IFakeOptionsBuilder<T> options)
+        private void ApplyOptions<T>(IFakeOptions<T> options)
         {
             if (this._strict)
             {

--- a/src/Autofac.Extras.FakeItEasy/packages.config
+++ b/src/Autofac.Extras.FakeItEasy/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.3.1" targetFramework="net40" />
-  <package id="FakeItEasy" version="2.0.0-beta007" targetFramework="net40" />
+  <package id="FakeItEasy" version="2.0.0-rc1" targetFramework="net40" />
 </packages>

--- a/test/Autofac.Extras.Tests.FakeItEasy/Autofac.Extras.Tests.FakeItEasy.csproj
+++ b/test/Autofac.Extras.Tests.FakeItEasy/Autofac.Extras.Tests.FakeItEasy.csproj
@@ -62,8 +62,8 @@
       <HintPath>..\..\packages\Autofac.3.3.1\lib\net40\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\FakeItEasy.2.0.0-beta007\lib\net40\FakeItEasy.dll</HintPath>
+      <HintPath>..\..\packages\FakeItEasy.2.0.0-rc1\lib\net40\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>

--- a/test/Autofac.Extras.Tests.FakeItEasy/packages.config
+++ b/test/Autofac.Extras.Tests.FakeItEasy/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.3.1" targetFramework="net40" />
-  <package id="FakeItEasy" version="2.0.0-beta007" targetFramework="net40" />
+  <package id="FakeItEasy" version="2.0.0-rc1" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
If all goes well with RC1 then the stable 2.0.0 package will be built from the same commit, so all that will need doing after 2.0.0 is released is to update the package, rebuild and release.