### PR TITLE
Upgrade to FakeItEasy 3.2.0

### DIFF
--- a/src/Autofac.Extras.FakeItEasy/AutoFake.cs
+++ b/src/Autofac.Extras.FakeItEasy/AutoFake.cs
@@ -51,15 +51,11 @@ namespace Autofac.Extras.FakeItEasy
         /// <param name="callsBaseMethods">
         /// <see langword="true" /> to delegate configured method calls to the base method of the faked method.
         /// </param>
-        /// <param name="callsDoNothing">
-        /// <see langword="true" /> to configure fake calls to do nothing when called.
-        /// </param>
         /// <param name="builder">The container builder to use to build the container.</param>
         /// <param name="configureFake">Specifies an action that should be run over a fake object before it's created.</param>
         public AutoFake(
             bool strict = false,
             bool callsBaseMethods = false,
-            bool callsDoNothing = false,
             Action<object> configureFake = null,
             ContainerBuilder builder = null)
         {
@@ -69,7 +65,7 @@ namespace Autofac.Extras.FakeItEasy
             }
 
             builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource().WithRegistrationsAs(b => b.InstancePerLifetimeScope()));
-            builder.RegisterSource(new FakeRegistrationHandler(strict, callsBaseMethods, callsDoNothing, configureFake));
+            builder.RegisterSource(new FakeRegistrationHandler(strict, callsBaseMethods, configureFake));
             this._container = builder.Build();
             this._container.BeginLifetimeScope();
         }

--- a/src/Autofac.Extras.FakeItEasy/Autofac.Extras.FakeItEasy.csproj
+++ b/src/Autofac.Extras.FakeItEasy/Autofac.Extras.FakeItEasy.csproj
@@ -49,9 +49,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Autofac.3.3.1\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FakeItEasy.2.0.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Autofac.Extras.FakeItEasy/FakeRegistrationHandler.cs
+++ b/src/Autofac.Extras.FakeItEasy/FakeRegistrationHandler.cs
@@ -41,7 +41,6 @@ namespace Autofac.Extras.FakeItEasy
         private readonly MethodInfo _createMethod;
         private readonly bool _strict;
         private readonly bool _callsBaseMethods;
-        private readonly bool _callsDoNothing;
         private readonly Action<object> _configureFake;
 
         /// <summary>
@@ -49,13 +48,11 @@ namespace Autofac.Extras.FakeItEasy
         /// </summary>
         /// <param name="strict">Whether fakes should be created with strict semantics.</param>
         /// <param name="callsBaseMethods">Whether fakes should call base methods.</param>
-        /// <param name="callsDoNothing">Whether calls to fakes should do nothing.</param>
         /// <param name="configureFake">An action to perform on a fake before it's created.</param>
-        public FakeRegistrationHandler(bool strict, bool callsBaseMethods, bool callsDoNothing, Action<object> configureFake)
+        public FakeRegistrationHandler(bool strict, bool callsBaseMethods, Action<object> configureFake)
         {
             this._strict = strict;
             this._callsBaseMethods = callsBaseMethods;
-            this._callsDoNothing = callsDoNothing;
             this._configureFake = configureFake;
 
             // NOTE (adamralph): inspired by http://blog.functionalfun.net/2009/10/getting-methodinfo-of-generic-method.html
@@ -121,11 +118,6 @@ namespace Autofac.Extras.FakeItEasy
             if (this._callsBaseMethods)
             {
                 A.CallTo(fake).CallsBaseMethod();
-            }
-
-            if (this._callsDoNothing)
-            {
-                A.CallTo(fake).DoesNothing();
             }
 
             return fake;

--- a/src/Autofac.Extras.FakeItEasy/packages.config
+++ b/src/Autofac.Extras.FakeItEasy/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.3.1" targetFramework="net40" />
-  <package id="FakeItEasy" version="2.0.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net451" />
 </packages>

--- a/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
+++ b/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
@@ -90,17 +90,6 @@ namespace Autofac.Extras.FakeItEasy.Test
         }
 
         [Fact]
-        public void CanResolveFakesWhichDoNotRespondToCalls()
-        {
-            using (var fake = new AutoFake(callsDoNothing: true))
-            {
-                var bar = fake.Resolve<IBar>();
-                var result = bar.Spawn();
-                Assert.Null(result);
-            }
-        }
-
-        [Fact]
         public void CanResolveFakesWhichInvokeActionsWhenResolved()
         {
             var resolvedFake = (object)null;

--- a/test/Autofac.Extras.FakeItEasy.Test/Autofac.Extras.FakeItEasy.Test.csproj
+++ b/test/Autofac.Extras.FakeItEasy.Test/Autofac.Extras.FakeItEasy.Test.csproj
@@ -67,9 +67,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Autofac.3.3.1\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FakeItEasy.2.0.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/test/Autofac.Extras.FakeItEasy.Test/packages.config
+++ b/test/Autofac.Extras.FakeItEasy.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.3.1" targetFramework="net40" />
-  <package id="FakeItEasy" version="2.0.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />


### PR DESCRIPTION
Supports #10

As discussed, I removed the `callsDoNothing` option, since it's now the default behavior for fakes.