### PR TITLE
Allow calls to faked abstract methods when using callsBaseMethods

### DIFF
--- a/src/Autofac.Extras.FakeItEasy/FakeRegistrationHandler.cs
+++ b/src/Autofac.Extras.FakeItEasy/FakeRegistrationHandler.cs
@@ -1,5 +1,5 @@
 // This software is part of the Autofac IoC container
-// Copyright (c) 2007 - 2008 Autofac Contributors
+// Copyright (c) 2007 - 2018 Autofac Contributors
 // http://autofac.org
 //
 // Permission is hereby granted, free of charge, to any person
@@ -103,26 +103,24 @@ namespace Autofac.Extras.FakeItEasy
         /// <returns>A fake object.</returns>
         private object CreateFake(TypedService typedService)
         {
-            var fake = Create.Fake(typedService.ServiceType, this.ApplyOptions);
-
-            if (this._callsBaseMethods)
-            {
-                A.CallTo(fake).CallsBaseMethod();
-            }
-
-            return fake;
+            return Create.Fake(typedService.ServiceType, this.ApplyOptions);
         }
 
         private void ApplyOptions(IFakeOptions options)
         {
             if (this._strict)
             {
-                options.Strict();
+                options = options.Strict();
             }
 
             if (this._configureFake != null)
             {
-                options.ConfigureFake(x => this._configureFake(x));
+                options = options.ConfigureFake(x => this._configureFake(x));
+            }
+
+            if (this._callsBaseMethods)
+            {
+                options.CallsBaseMethods();
             }
         }
     }

--- a/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
+++ b/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
@@ -90,6 +90,16 @@ namespace Autofac.Extras.FakeItEasy.Test
         }
 
         [Fact]
+        public void CanResolveFakesWhichCallsBaseMethodsAndInvokeAbstractMethod()
+        {
+            using (var fake = new AutoFake(callsBaseMethods: true))
+            {
+                var bar = fake.Resolve<Bar>();
+                bar.GoAbstractly();
+            }
+        }
+
+        [Fact]
         public void CanResolveFakesWhichInvokeActionsWhenResolved()
         {
             var resolvedFake = (object)null;
@@ -198,6 +208,8 @@ namespace Autofac.Extras.FakeItEasy.Test
             {
                 throw new NotImplementedException();
             }
+
+            public abstract void GoAbstractly();
         }
 
         public class Baz : IBaz


### PR DESCRIPTION
Fixes #15.

Looks to conflict with #11, but if that PR is merged, I'm happy to rebase on top of it.