### PR TITLE
Obtain instances from previous scopes

### DIFF
--- a/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
+++ b/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
@@ -202,7 +202,7 @@ namespace Autofac.Extras.FakeItEasy.Test
                 fake.Provide(new Baz());
                 var bar2 = fake.Resolve<IBar>();
 
-                Assert.Equal(bar, bar2);
+                Assert.Same(bar, bar2);
             }
         }
 

--- a/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
+++ b/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
@@ -193,6 +193,19 @@ namespace Autofac.Extras.FakeItEasy.Test
             }
         }
 
+        [Fact]
+        public void ReturnsInstanceFromChildScope()
+        {
+            using (var fake = new AutoFake())
+            {
+                var bar = fake.Resolve<IBar>();
+                fake.Provide(new Baz());
+                var bar2 = fake.Resolve<IBar>();
+
+                Assert.Equal(bar, bar2);
+            }
+        }
+
         public abstract class Bar : IBar
         {
             private bool _gone;


### PR DESCRIPTION
It fixes issue #22. 

I tried to write an approach that doesn't need to change anything on Autofac main code, just in this FakeItEasy repository. Almost every method I saw for checking registered services (example: scope.IsRegistered) creates a new instance if they don't find it, so I wrote the below approach. 

I also found that the first scope created was not being disposed of, so I also fixed it. 