### PR TITLE
Remove Provide() methods and builder parameter from AutoFake

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,77 @@ Please file issues and pull requests for this package in this repository rather 
 
 ## Quick Start
 
-The primary entry point for this integration is the `Autofac.Extras.FakeItEasy.AutoFake` class. Once you create an `AutoFake`, you can start "resolving" classes from the provider where dependencies will be automatically filled in by Autofac.
+The primary entry point for this integration is the `Autofac.Extras.FakeItEasy.AutoFake` class. Once you create an `AutoFake`, you can `Resolve` the class under test and Autofac will automatically fill its constructor dependencies with FakeItEasy fakes. You then configure and assert on those fakes the way you normally would with FakeItEasy.
 
 ```csharp
 [Fact]
-public void TwoAutoFakedInstances()
+public void DependenciesAreAutomaticallyFaked()
 {
     using (var fake = new AutoFake())
     {
-        var bar1 = fake.Resolve<IBar>();
-        var bar2 = fake.Resolve<IBar>();
+        // Configure the fake dependency that will be injected.
+        A.CallTo(() => fake.Resolve<IDependency>().GetValue()).Returns("expected value");
 
-        Assert.Same(bar1, bar2);
+        // Resolve the system under test; its IDependency is the fake configured above.
+        var sut = fake.Resolve<SystemUnderTest>();
+
+        // Act and assert as usual.
+        Assert.Equal("expected value", sut.DoWork());
+        A.CallTo(() => fake.Resolve<IDependency>().GetValue()).MustHaveHappened();
     }
 }
 ```
+
+To inject a specific instance or implementation instead of an automatic fake, register it through the `configureAction` constructor argument:
+
+```csharp
+var dependency = new Dependency();
+using (var fake = new AutoFake(configureAction: cfg => cfg.RegisterInstance(dependency).As<IDependency>()))
+{
+    // SystemUnderTest receives your dependency instance.
+    var sut = fake.Resolve<SystemUnderTest>();
+}
+```
+
+See the [documentation](https://autofac.readthedocs.io/en/latest/integration/fakeiteasy.html) for more usage details and options.
+
+## Migrating from 7.0.0
+
+Version 8.0.0 removed the `AutoFake.Provide<TService>(instance)` and `AutoFake.Provide<TService, TImplementation>()` methods. Each `Provide` call started a new lifetime scope, which meant a fake resolved _before_ the call was a different instance than the one injected _afterward_ - so configuration applied to the earlier fake silently had no effect.
+
+Register specific dependencies through the `configureAction` constructor argument instead. Everything is registered into a single scope before the container is built, so the instances you configure are the instances that get injected.
+
+```csharp
+// Before (7.0.0)
+using (var fake = new AutoFake())
+{
+    var dependency = A.Fake<IDependency>();
+    fake.Provide(dependency);
+    var sut = fake.Resolve<SystemUnderTest>();
+}
+
+// After (8.0.0)
+var dependency = A.Fake<IDependency>();
+using (var fake = new AutoFake(configureAction: cfg => cfg.RegisterInstance(dependency).As<IDependency>()))
+{
+    var sut = fake.Resolve<SystemUnderTest>();
+}
+```
+
+For implementation registrations, register the type in `configureAction` and move any Autofac parameters onto the registration with `WithParameter`:
+
+```csharp
+// Before (7.0.0): fake.Provide<IDependency, Dependency>();
+// After (8.0.0):
+using (var fake = new AutoFake(configureAction: cfg => cfg.RegisterType<Dependency>().As<IDependency>()))
+{
+    var sut = fake.Resolve<SystemUnderTest>();
+}
+```
+
+Version 8.0.0 also removed the `builder` constructor parameter (the one that let you pass your own `ContainerBuilder`). It was redundant with `configureAction`, so move any registrations from your own builder into the `configureAction` callback.
+
+See the [Migrating from 7.0.0](https://autofac.readthedocs.io/en/latest/integration/fakeiteasy.html#migrating-from-7-0-0) documentation for the full details.
 
 ## Get Help
 

--- a/src/Autofac.Extras.FakeItEasy/AutoFake.cs
+++ b/src/Autofac.Extras.FakeItEasy/AutoFake.cs
@@ -14,12 +14,9 @@ namespace Autofac.Extras.FakeItEasy;
 [SecurityCritical]
 public class AutoFake : IDisposable
 {
-    private readonly Stack<ILifetimeScope> _scopes = new Stack<ILifetimeScope>();
+    private readonly ILifetimeScope _scope;
 
     private bool _disposed;
-
-    [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", Justification = "It's only a reference, dispose is called from the _scopes Stack")]
-    private ILifetimeScope _currentScope;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AutoFake" /> class.
@@ -31,23 +28,25 @@ public class AutoFake : IDisposable
     /// <param name="callsBaseMethods">
     /// <see langword="true" /> to delegate configured method calls to the base method of the faked method.
     /// </param>
-    /// <param name="builder">The container builder to use to build the container.</param>
     /// <param name="configureFake">Specifies an action that should be run over a fake object before it's created.</param>
-    /// <param name="configureAction">Specifies actions that needs to be performed on the container builder, like registering additional services.</param>
+    /// <param name="configureAction">
+    /// Specifies actions that need to be performed on the container builder, like registering additional services.
+    /// Use this to provide specific dependency instances or implementations to the system under test (for example,
+    /// <c>configureAction: b =&gt; b.RegisterInstance(myDependency).As&lt;IDependency&gt;()</c>).
+    /// </param>
     public AutoFake(
         bool strict = false,
         bool callsBaseMethods = false,
         Action<object>? configureFake = null,
-        ContainerBuilder? builder = null,
         Action<ContainerBuilder>? configureAction = null)
     {
-        builder ??= new ContainerBuilder();
+        var builder = new ContainerBuilder();
 
         builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource().WithRegistrationsAs(b => b.InstancePerLifetimeScope()));
         builder.RegisterSource(new FakeRegistrationHandler(strict, callsBaseMethods, configureFake));
         configureAction?.Invoke(builder);
         Container = builder.Build();
-        _currentScope = Container.BeginLifetimeScope();
+        _scope = Container.BeginLifetimeScope();
     }
 
     /// <summary>
@@ -87,51 +86,7 @@ public class AutoFake : IDisposable
     /// <returns>The service.</returns>
     public T Resolve<T>(params Parameter[] parameters)
         where T : notnull
-            => _currentScope.Resolve<T>(parameters);
-
-    /// <summary>
-    /// Resolve the specified type in the container (register it if needed).
-    /// </summary>
-    /// <typeparam name="TService">The type of the service.</typeparam>
-    /// <typeparam name="TImplementation">The implementation of the service.</typeparam>
-    /// <param name="parameters">Optional parameters.</param>
-    /// <returns>The service.</returns>
-    [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The component registry is responsible for registration disposal.")]
-    public TService Provide<TService, TImplementation>(params Parameter[] parameters)
-        where TImplementation : notnull
-        where TService : notnull
-    {
-        var scope = _currentScope.BeginLifetimeScope(b =>
-        {
-            b.RegisterType<TImplementation>().As<TService>().InstancePerLifetimeScope();
-        });
-
-        _scopes.Push(scope);
-        _currentScope = scope;
-
-        return _currentScope.Resolve<TService>(parameters);
-    }
-
-    /// <summary>
-    /// Resolve the specified type in the container (register specified instance if needed).
-    /// </summary>
-    /// <typeparam name="TService">The type of the service.</typeparam>
-    /// <param name="instance">The instance to register if needed.</param>
-    /// <returns>The instance resolved from container.</returns>
-    [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The component registry is responsible for registration disposal.")]
-    public TService Provide<TService>(TService instance)
-        where TService : class
-    {
-        var scope = _currentScope.BeginLifetimeScope(b =>
-        {
-            b.Register(c => instance).InstancePerLifetimeScope();
-        });
-
-        _scopes.Push(scope);
-        _currentScope = scope;
-
-        return _currentScope.Resolve<TService>();
-    }
+            => _scope.Resolve<T>(parameters);
 
     /// <summary>
     /// Handles disposal of managed and unmanaged resources.
@@ -148,11 +103,7 @@ public class AutoFake : IDisposable
         {
             if (disposing)
             {
-                while (_scopes.Count > 0)
-                {
-                    _scopes.Pop().Dispose();
-                }
-
+                _scope.Dispose();
                 Container.Dispose();
             }
 

--- a/src/Autofac.Extras.FakeItEasy/AutoFake.cs
+++ b/src/Autofac.Extras.FakeItEasy/AutoFake.cs
@@ -22,17 +22,24 @@ public class AutoFake : IDisposable
     /// Initializes a new instance of the <see cref="AutoFake" /> class.
     /// </summary>
     /// <param name="strict">
-    /// <see langword="true" /> to create strict fakes.
-    /// This means that any calls to the fakes that have not been explicitly configured will throw an exception.
+    /// <see langword="true" /> to create strict fakes. This means that any
+    /// calls to the fakes that have not been explicitly configured will throw
+    /// an exception.
     /// </param>
     /// <param name="callsBaseMethods">
-    /// <see langword="true" /> to delegate configured method calls to the base method of the faked method.
+    /// <see langword="true" /> to delegate configured method calls to the base
+    /// method of the faked method.
     /// </param>
-    /// <param name="configureFake">Specifies an action that should be run over a fake object before it's created.</param>
+    /// <param name="configureFake">
+    /// Specifies an action that should be run over a fake object before it's
+    /// created.
+    /// </param>
     /// <param name="configureAction">
-    /// Specifies actions that need to be performed on the container builder, like registering additional services.
-    /// Use this to provide specific dependency instances or implementations to the system under test (for example,
-    /// <c>configureAction: b =&gt; b.RegisterInstance(myDependency).As&lt;IDependency&gt;()</c>).
+    /// Specifies actions that need to be performed on the container builder,
+    /// like registering additional services. Use this to provide specific
+    /// dependency instances or implementations to the system under test (for
+    /// example, <c>configureAction: b =&gt;
+    /// b.RegisterInstance(myDependency).As&lt;IDependency&gt;()</c>).
     /// </param>
     public AutoFake(
         bool strict = false,
@@ -92,10 +99,10 @@ public class AutoFake : IDisposable
     /// Handles disposal of managed and unmanaged resources.
     /// </summary>
     /// <param name="disposing">
-    /// <see langword="true" /> to dispose of managed resources (during a manual execution
-    /// of <see cref="AutoFake.Dispose()"/>); or
-    /// <see langword="false" /> if this is getting run as part of finalization where
-    /// managed resources may have already been cleaned up.
+    /// <see langword="true" /> to dispose of managed resources (during a manual
+    /// execution of <see cref="AutoFake.Dispose()"/>); or
+    /// <see langword="false" /> if this is getting run as part of finalization
+    /// where managed resources may have already been cleaned up.
     /// </param>
     protected virtual void Dispose(bool disposing)
     {

--- a/src/Autofac.Extras.FakeItEasy/FakeRegistrationHandler.cs
+++ b/src/Autofac.Extras.FakeItEasy/FakeRegistrationHandler.cs
@@ -4,13 +4,17 @@
 using System.Reflection;
 using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Features.Metadata;
+using Autofac.Features.OwnedInstances;
 using FakeItEasy;
 using FakeItEasy.Creation;
 using FakeItEasy.Sdk;
 
 namespace Autofac.Extras.FakeItEasy;
 
-/// <summary> Resolves unknown interfaces and Fakes. </summary>
+/// <summary>
+/// Resolves unknown interfaces and fakes.
+/// </summary>
 internal sealed class FakeRegistrationHandler : IRegistrationSource
 {
     private readonly bool _strict;
@@ -31,8 +35,10 @@ internal sealed class FakeRegistrationHandler : IRegistrationSource
     }
 
     /// <summary>
-    /// Gets a value indicating whether the registrations provided by this source are 1:1 adapters on top
-    /// of other components (I.e. like Meta, Func or Owned.)
+    /// Gets a value indicating whether the registrations provided by this
+    /// source are 1:1 adapters on top of other components (i.e.,
+    /// <see cref="Meta{T}"/>, <see cref="Func{T}"/>, or
+    /// <see cref="Owned{T}"/>.)
     /// </summary>
     public bool IsAdapterForIndividualComponents => false;
 
@@ -40,9 +46,15 @@ internal sealed class FakeRegistrationHandler : IRegistrationSource
     /// Retrieve registrations for an unregistered service, to be used
     /// by the container.
     /// </summary>
-    /// <param name="service">The service that was requested.</param>
-    /// <param name="registrationAccessor">A function that will return existing registrations for a service.</param>
-    /// <returns>Registrations providing the service.</returns>
+    /// <param name="service">
+    /// The service that was requested.
+    /// </param>
+    /// <param name="registrationAccessor">
+    /// A function that will return existing registrations for a service.
+    /// </param>
+    /// <returns>
+    /// Registrations providing the service.
+    /// </returns>
     public IEnumerable<IComponentRegistration> RegistrationsFor(
         Service service, Func<Service, IEnumerable<ServiceRegistration>> registrationAccessor)
     {

--- a/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
+++ b/test/Autofac.Extras.FakeItEasy.Test/AutoFakeFixture.cs
@@ -7,23 +7,6 @@ namespace Autofac.Extras.FakeItEasy.Test;
 
 public class AutoFakeFixture
 {
-    public interface IBar
-    {
-        bool Gone
-        {
-            get;
-        }
-
-        void Go();
-
-        IBar Spawn();
-    }
-
-    public interface IBaz
-    {
-        void Go();
-    }
-
     [Fact]
     public void ByDefaultAbstractTypesAreResolvedToTheSameSharedInstance()
     {
@@ -128,9 +111,9 @@ public class AutoFakeFixture
     [Fact]
     public void ProvidesImplementations()
     {
-        using (var fake = new AutoFake())
+        using (var fake = new AutoFake(configureAction: b => b.RegisterType<Baz>().As<IBaz>()))
         {
-            var baz = fake.Provide<IBaz, Baz>();
+            var baz = fake.Resolve<IBaz>();
 
             Assert.NotNull(baz);
             Assert.True(baz is Baz);
@@ -140,11 +123,9 @@ public class AutoFakeFixture
     [Fact]
     public void ProvidesInstances()
     {
-        using (var fake = new AutoFake())
+        var bar = A.Fake<IBar>();
+        using (var fake = new AutoFake(configureAction: b => b.RegisterInstance(bar).As<IBar>()))
         {
-            var bar = A.Fake<IBar>();
-            fake.Provide(bar);
-
             var foo = fake.Resolve<Foo>();
             foo.Go();
 
@@ -153,12 +134,31 @@ public class AutoFakeFixture
     }
 
     [Fact]
+    public void ProvidedInstanceIsTheSameInstanceResolvedAfterConfiguration()
+    {
+        // Regression test for #19 and #22: a dependency configured at build
+        // time must be the exact instance injected into the system under test,
+        // with no extra lifetime scope.
+        var bar = A.Fake<IBar>();
+        using (var fake = new AutoFake(configureAction: b => b.RegisterInstance(bar).As<IBar>()))
+        {
+            A.CallTo(() => bar.Gone).Returns(true);
+
+            var resolved = fake.Resolve<IBar>();
+
+            Assert.Same(bar, resolved);
+            Assert.True(resolved.Gone);
+        }
+    }
+
+    [Fact]
     public void CallsBaseMethodsOverridesStrict()
     {
-        // A characterization test, intended to detect accidental changes in behavior.
-        // This is an odd situation, since specifying both strict and callsBaseMethods only makes
-        // sense when there are concrete methods on the fake that we want to be executed, but we
-        // want to reject the invocation of any methods that are left abstract on the faked type.
+        // A characterization test, intended to detect accidental changes in
+        // behavior. This is an odd situation, since specifying both strict and
+        // callsBaseMethods only makes sense when there are concrete methods on
+        // the fake that we want to be executed, but we want to reject the
+        // invocation of any methods that are left abstract on the faked type.
         using (var fake = new AutoFake(callsBaseMethods: true, strict: true))
         {
             var bar = fake.Resolve<Bar>();
@@ -170,9 +170,10 @@ public class AutoFakeFixture
     [Fact]
     public void CallsBaseMethodsOverridesConfigureFake()
     {
-        // A characterization test, intended to detect accidental changes in behavior.
-        // Since callsBaseMethods applies globally and configureFake can affect individual
-        // members, having configureFake override callsBaseMethods may be preferred.
+        // A characterization test, intended to detect accidental changes in
+        // behavior. Since callsBaseMethods applies globally and configureFake
+        // can affect individual members, having configureFake override
+        // callsBaseMethods may be preferred.
         using (var fake = new AutoFake(
             callsBaseMethods: true,
             configureFake: f => A.CallTo(() => ((Bar)f).Go()).DoesNothing()))
@@ -194,6 +195,23 @@ public class AutoFakeFixture
             var exception = Record.Exception(() => bar.Go());
             Assert.Null(exception);
         }
+    }
+
+    public interface IBar
+    {
+        bool Gone
+        {
+            get;
+        }
+
+        void Go();
+
+        IBar Spawn();
+    }
+
+    public interface IBaz
+    {
+        void Go();
     }
 
     public abstract class Bar : IBar


### PR DESCRIPTION
## Summary

Resolves the long-standing confusion behind issues #19 and #22 by removing the `AutoFake.Provide<T>()` methods, and removes the now-redundant `builder` constructor parameter. This brings `AutoFake` in line with the sibling `Autofac.Extras.Moq` integration, which exposes a single `beforeBuild`-style callback and no `Provide()`.

This is a breaking change targeted for the **8.0.0** major release.

## Background

Each `Provide()` call did `_currentScope.BeginLifetimeScope(...)` and reassigned the current scope. As a result, a fake resolved *before* `Provide()` was a different instance than the one injected *afterward* — so configuration applied to the earlier fake (e.g. via `A.CallTo(...)`) silently had no effect. This is the root cause of both #19 and #22.

The fix is to register specific dependencies through the existing `configureAction` constructor argument, which registers everything into a single scope before the container is built.

## Changes

- **Removed** `Provide<TService>(instance)` and `Provide<TService, TImplementation>()`. Use the `configureAction` constructor argument instead.
- **Removed** the `builder` constructor parameter (redundant with `configureAction`, and it bypassed the registration ordering `AutoFake` relies on). The `ContainerBuilder` is now always created internally, matching `AutoMock`.
- Simplified `AutoFake` to resolve from a single lifetime scope (no more per-`Provide` scope stack).
- Migrated the affected tests to `configureAction` and added a regression test (`ProvidedInstanceIsTheSameInstanceResolvedAfterConfiguration`) covering #19 / #22.
- Updated the README quick start and added a "Migrating from 7.0.0" section.

## Testing

- `dotnet test` — all 15 tests pass on net8.0 and net10.0.
- `dotnet format --verify-no-changes` passes.

Closes #19
Closes #22

Companion docs PR updates the FakeItEasy integration page.